### PR TITLE
fix: issue with small pes packets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ coverage/*
 *.log
 *.obj
 *.tlog
+**/*.o.dSYM/*
 **/Debug/*
 **/Release/*

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ remove:
 	rm -r -f $(INSTALL_DIR)/include/libtsdemux
 	rm -f $(INSTALL_DIR)/lib/libtsdemux.a
 
+test: static $(OBJ_TESTS)
 tests: static $(OBJ_TESTS)
 
 examples: static $(OBJ_EXAMPLES)
@@ -74,6 +75,7 @@ endif
 
 clean:
 	rm -f -r $(ODIR) $(CCDIR)
+	rm -f -r test/*.o.dSYM
 	find . -type f -name '*.o' -exec rm {} \;
 	find . -type f -name '*.o.dSYM' -exec rm {} \;
 	find . -type f -name '*.o.gcno' -exec rm {} \;

--- a/src/tsdemux.h
+++ b/src/tsdemux.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 
 // Software version, format MAJOR.MINOR.PATCH
-#define TSD_VERSION                             "0.1.0"
+#define TSD_VERSION                             "0.1.1"
 
 #define TSD_SYNC_BYTE                           (0x47)
 #define TSD_MESSAGE_LEN                         (128)


### PR DESCRIPTION
Fixing issue (#7) with small PES packets (< 6 bytes of data) not correctly being appended to the PES data buffer.
This resulted in the `TSD_EVENT_PES` event from being fired with PES data that excluded the last small packet.