### PR TITLE
Arduino and C++ Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage/*
 **/*.o.dSYM/*
 **/Debug/*
 **/Release/*
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.16)
+
+# set the project name
+project(tsdemux)
+
+# lots of warnings and all warnings as errors
+## add_compile_options(-Wall -Wextra )
+set(CMAKE_CXX_STANDARD 17)
+
+file(GLOB_RECURSE SRC_LIST_C CONFIGURE_DEPENDS  "${PROJECT_SOURCE_DIR}/src/*.c" )
+
+# define libraries
+add_library (tsdemux ${SRC_LIST_C})
+
+# define location for header files
+target_include_directories(tsdemux PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src )
+

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=tsdemux
+version=0.1.0
+author= Joel Freeman (https://github.com/frejoel)
+maintainer=Phil Schatzmann (https://github.com/pschatzmann)
+sentence=MPEG-TS (MTS) Demuxer
+paragraph=MPEG-TS (MTS) Demuxer
+category=Communication
+url=https://github.com/pschatzmann/arduino-tsdemux.git
+architectures=*

--- a/src/tsdemux.h
+++ b/src/tsdemux.h
@@ -37,6 +37,12 @@
 #define TSD_MEM_PAGE_SIZE                       (1024)
 #define TSD_MAX_PID_REGS                        (16)
 
+// C++ support
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 /**
  * @file
  * @ingroup tsdemux
@@ -47,6 +53,24 @@
 typedef struct TSDemuxContext TSDemuxContext;
 typedef struct TSDTable TSDTable;
 typedef struct TSDTableSection TSDTableSection;
+
+/**
+ * Event Id.
+ * The Id of all events that may occur during demux. 
+ * (Moved here because forward declaration not allowed on enum!)
+ */
+typedef enum TSDEventId {
+    TSD_EVENT_PAT                            = 0x0001,
+    TSD_EVENT_PMT                            = 0x0002,
+    TSD_EVENT_CAT                            = 0x0004,
+    TSD_EVENT_TSDT                           = 0x0008,
+    /// Unsupported TSDTable
+    TSD_EVENT_TABLE                          = 0x0010,
+    // User Registered PES data
+    TSD_EVENT_PES                            = 0x0020,
+    // User Registered Adaptionn Field Private Data
+    TSD_EVENT_ADAP_FIELD_PRV_DATA            = 0x0040,
+} TSDEventId;
 
 typedef enum TSDEventId TSDEventId;
 
@@ -349,22 +373,6 @@ typedef enum TSDPMTStreamType {
     TSD_PMT_STREAM_TYPE_ATSC_USER_PRIV               = 0xEB,
 } TSDPMTStreamType;
 
-/**
- * Event Id.
- * The Id of all events that may occur during demux.
- */
-typedef enum TSDEventId {
-    TSD_EVENT_PAT                            = 0x0001,
-    TSD_EVENT_PMT                            = 0x0002,
-    TSD_EVENT_CAT                            = 0x0004,
-    TSD_EVENT_TSDT                           = 0x0008,
-    /// Unsupported TSDTable
-    TSD_EVENT_TABLE                          = 0x0010,
-    // User Registered PES data
-    TSD_EVENT_PES                            = 0x0020,
-    // User Registered Adaptionn Field Private Data
-    TSD_EVENT_ADAP_FIELD_PRV_DATA            = 0x0040,
-} TSDEventId;
 
 /**
  * Registration Type.
@@ -1567,5 +1575,11 @@ TSDCode tsd_parse_descriptor_fmx_buffer_size(const uint8_t *data,
 TSDCode tsd_parse_descriptor_multiplex_buffer(const uint8_t *data,
         size_t size,
         TSDDescriptorMultiplexBuffer *desc);
+
+
+#ifdef __cplusplus
+}
+#endif
+
 
 #endif // TS_DEMUX_H


### PR DESCRIPTION
- added library.properties so that project can be used as Arduino Library
- added support for C++
- moved enum TSDEventId  to beginning to avoid compile errors in C++
- added cmake support so that library can be installed with FetchContent
