### PR TITLE
ts_demux aguments change (Issue #13)

### DIFF
--- a/examples/tsinfo.c
+++ b/examples/tsinfo.c
@@ -70,8 +70,7 @@ int main(int argc, char **charv) {
 
         if(count > 0) {
             // with res, we could report any errors found during demuxing
-            TSDCode res;
-            parsed = tsd_demux(&ctx, buffer, count, &res);
+            TSDCode res = tsd_demux(&ctx, buffer, count, &parsed);
         }else{
             parsed = 0;
         }

--- a/src/tsdemux.c
+++ b/src/tsdemux.c
@@ -1427,22 +1427,20 @@ TSDCode demux_adaptation_field_prv_data(TSDemuxContext *ctx, TSDPacket *hdr, int
     return TSD_OK;
 }
 
-size_t tsd_demux(TSDemuxContext *ctx,
+TSDCode tsd_demux(TSDemuxContext *ctx,
                  void *data,
                  size_t size,
-                 TSDCode *code)
+                 size_t *parsedSize)
 {
+    // initially set parsedSize to 0
+    if(parsedSize != NULL) *parsedSize = 0;
+
     if(ctx == NULL)         return TSD_INVALID_CONTEXT;
     if(data == NULL)        return TSD_INVALID_DATA;
     if(size == 0)           return TSD_INVALID_DATA_SIZE;
 
     uint8_t *ptr = (uint8_t*)data;
     size_t remaining = size;
-
-    // initially set the code to OK
-    if(code != NULL) {
-        *code = TSD_OK;
-    }
 
     TSDPacket hdr;
     TSDCode res;
@@ -1546,7 +1544,8 @@ size_t tsd_demux(TSDemuxContext *ctx,
         ctx->buffers.length = 0;
     }
 
-    return size - remaining;
+    if (parsedSize != NULL) *parsedSize = size - remaining;
+    return TSD_OK;
 }
 
 TSDCode tsd_demux_end(TSDemuxContext *ctx)

--- a/src/tsdemux.h
+++ b/src/tsdemux.h
@@ -1021,11 +1021,10 @@ TSDCode tsd_set_event_callback(TSDemuxContext *ctx, tsd_on_event callback);
  * @param ctx The contenxt being used to demux,
  * @param data The data to demux.
  * @param size The size of data.
- * @param code Used to store the return code of this process.
- * @return The total number of bytes parsed. The process result is stored in
- * code which on success will be TSD_OK;
+ * @param parsedSize The total number of bytes parsed will be populated in parsedSize. This will be 0 if an error is returned.
+ * @return Returns TSD_OK on success.
  */
-size_t tsd_demux(TSDemuxContext *ctx, void *data, size_t size, TSDCode *code);
+TSDCode tsd_demux(TSDemuxContext *ctx, void *data, size_t size, size_t *parsedSize);
 
 /**
  * Ends the Demuxxing process.


### PR DESCRIPTION
Changing the signature of `tsd_demux` so that it returns only a valid `TSDCode`, and the parsed number of bytes can be optionally populated via an argument.
This stops any confusion between an error code vs the number of bytes parsed  (#13).